### PR TITLE
[Fix/company api] 중복호출로 인한 삭제 오류 해결 

### DIFF
--- a/com.rush.logistic.client.company-product/src/main/java/com/rush/logistic/client/company_product/domain/controller/CompanyController.java
+++ b/com.rush.logistic.client.company-product/src/main/java/com/rush/logistic/client/company_product/domain/controller/CompanyController.java
@@ -49,7 +49,7 @@ public class CompanyController {
     @DeleteMapping("/{id}")
     public Response<?> deleteCompany(@PathVariable UUID id) {
         companyService.deleteCompany(id);
-        return Response.success(companyService.deleteCompany(id),"가게 정보가 삭제되었습니다.");
+        return Response.success(null,"업체 삭제에 성공하였습니다.");
     }
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

삭제 성공 메세지를 하는 과정에서 delete 메서드를 두번 호출하여 에러가 발생하는 부분 -> null로 delete 중복호출을 안하며, 중복삭제 검토 가능
save 호출로 인한 오버헤드 발생 부분 제거
update 시 update시간이 저장 되기 전 시간으로 리턴값 주던 버그 -> entityManager로 해결

## PR 타입

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

* CompanyController 수정사항
  * DeleteCompany
```
    @DeleteMapping("/{id}")
    public Response<?> deleteCompany(@PathVariable UUID id) {
        companyService.deleteCompany(id);
        return Response.success(null,"업체 삭제에 성공하였습니다.");
    }
```
* CompanyService 수정사항
  * updateCompany
```
    private final EntityManager entityManager;
```
```
        entityManager.flush();

        entityManager.clear();

        Company companyForReturn = companyRepository.findById(id)
                .orElseThrow(() -> new ApplicationException(ErrorCode.COMPANY_NOT_FOUND));

        return CompanyDto.from(companyForReturn);
```

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

