### PR TITLE
[Refactor/slack, User api] Slack ,User Refactoring

### DIFF
--- a/com.rush.logistic.client.slack/build.gradle
+++ b/com.rush.logistic.client.slack/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	//zipkin
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/config/JpaConfig.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/config/JpaConfig.java
@@ -1,9 +1,22 @@
 package com.rush.logistic.client.slack.domain.config;
 
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
+    }
 }

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/controller/SlackController.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/controller/SlackController.java
@@ -1,9 +1,9 @@
 package com.rush.logistic.client.slack.domain.controller;
 
 
-import com.rush.logistic.client.slack.domain.dto.SlackInfoResponseDto;
 import com.rush.logistic.client.slack.domain.dto.SlackRequestDto;
 import com.rush.logistic.client.slack.domain.dto.SlackUpdateRequestDto;
+import com.rush.logistic.client.slack.domain.entity.SlackEntity;
 import com.rush.logistic.client.slack.domain.global.ApiResponse;
 import com.rush.logistic.client.slack.domain.service.SlackService;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ public class SlackController {
                                                       direction = Sort.Direction.DESC) Pageable pageable,
                                               @RequestParam Integer size){
 
-        Page<SlackInfoResponseDto> slacks = slackService.getAllSlacks(role, authenticatedUserId, pageable, size);
+        Page<SlackEntity> slacks = slackService.getAllSlacks(role, authenticatedUserId, pageable, size);
 
         return ApiResponse.ok(slacks);
     }
@@ -48,6 +48,14 @@ public class SlackController {
                                           @PathVariable String slackId) {
 
         return ApiResponse.ok(slackService.getSlack(role, authenticatedUserId, slackId));
+    }
+
+    @GetMapping("/slacks/message/{message}")
+    public ApiResponse<?> getSlackMessageByMessage(@RequestHeader(value = "role", required = true) String role,
+                                          @RequestHeader(value = "USER_ID", required = true) String authenticatedUserId,
+                                          @PathVariable String message) {
+
+        return ApiResponse.ok(slackService.getSlackByMessage(role, authenticatedUserId, message));
     }
 
     @PatchMapping("/slacks/{slackId}")

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/entity/SlackConstant.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/entity/SlackConstant.java
@@ -1,7 +1,0 @@
-package com.rush.logistic.client.slack.domain.entity;
-
-public class SlackConstant {
-
-    // Slack에 생성된 채널명을 작성합니다.
-    public static final String msa = "#msa";
-}

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/repository/SlackRepository.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/repository/SlackRepository.java
@@ -3,6 +3,6 @@ package com.rush.logistic.client.slack.domain.repository;
 import com.rush.logistic.client.slack.domain.entity.SlackEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SlackRepository extends JpaRepository<SlackEntity, Long> {
+public interface SlackRepository extends JpaRepository<SlackEntity, Long> ,SlackRepositoryCustom{
 
 }

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/repository/SlackRepositoryCustom.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/repository/SlackRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.rush.logistic.client.slack.domain.repository;
+
+import com.rush.logistic.client.slack.domain.entity.SlackEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface SlackRepositoryCustom {
+    Page<SlackEntity> findAll(Pageable pageable, int size);
+    List<SlackEntity> findByMessage(String message);
+    SlackEntity findBySlackId(Long slackId);
+}

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/repository/SlackRepositoryImpl.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/repository/SlackRepositoryImpl.java
@@ -1,0 +1,101 @@
+package com.rush.logistic.client.slack.domain.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rush.logistic.client.slack.domain.entity.QSlackEntity;
+import com.rush.logistic.client.slack.domain.entity.SlackEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+import static com.rush.logistic.client.slack.domain.entity.QSlackEntity.slackEntity;
+
+public class SlackRepositoryImpl extends QuerydslRepositorySupport implements SlackRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public SlackRepositoryImpl(JPAQueryFactory queryFactory) {
+        super(SlackEntity.class);
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<SlackEntity> findAll(Pageable pageable, int size){
+
+        pageable = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
+
+        JPAQuery<SlackEntity> query = queryFactory
+                .select(
+                        Projections.fields(
+                                SlackEntity.class,
+                                slackEntity.slackId,
+                                slackEntity.message,
+                                slackEntity.sendUserId,
+                                slackEntity.receiveUserSlackId,
+                                slackEntity.createdAt,
+                                slackEntity.createdBy,
+                                slackEntity.updatedAt,
+                                slackEntity.updatedBy
+                        )
+                )
+                .from(slackEntity)
+                .where(slackEntity.deletedAt.isNull());
+
+        List<SlackEntity> slacks = getQuerydsl().applyPagination(pageable,query).fetch();
+
+        long totalCount = slacks.size();
+
+        return new PageImpl<>(slacks, pageable, totalCount);
+    }
+
+//    @Cacheable("slackEntityCount")
+//    public long getTotalCount() {
+//        return queryFactory
+//                .select(slackEntity.slackId.count())
+//                .from(slackEntity)
+//                .where(slackEntity.deletedAt.isNull())
+//                .fetchOne();
+//    }
+
+    @Override
+    public List<SlackEntity> findByMessage(String message) {
+
+        return queryFactory
+                .selectFrom(QSlackEntity.slackEntity)
+                .where(
+                        QSlackEntity.slackEntity.deletedAt.isNull()
+                                .and(QSlackEntity.slackEntity.message.eq(message))
+                )
+                .fetch();
+    }
+
+    @Override
+    public SlackEntity findBySlackId(Long slackId) {
+
+        JPAQuery<SlackEntity> query = queryFactory
+                .select(
+                        Projections.fields(
+                                SlackEntity.class,
+                                slackEntity.slackId,
+                                slackEntity.message,
+                                slackEntity.sendUserId,
+                                slackEntity.receiveUserSlackId,
+                                slackEntity.createdAt,
+                                slackEntity.createdBy,
+                                slackEntity.updatedAt,
+                                slackEntity.updatedBy
+                        )
+                )
+                .from(slackEntity)
+                .where(slackEntity.deletedAt.isNull()
+                        .and(slackEntity.slackId.eq(slackId)));
+
+        return query.fetchOne();
+    }
+
+}

--- a/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/service/SlackService.java
+++ b/com.rush.logistic.client.slack/src/main/java/com/rush/logistic/client/slack/domain/service/SlackService.java
@@ -5,13 +5,13 @@ import com.rush.logistic.client.slack.domain.client.UserResponseDto;
 import com.rush.logistic.client.slack.domain.dto.SlackInfoResponseDto;
 import com.rush.logistic.client.slack.domain.dto.SlackRequestDto;
 import com.rush.logistic.client.slack.domain.dto.SlackUpdateRequestDto;
-import com.rush.logistic.client.slack.domain.dto.SlackUpdateResponseDto;
 import com.rush.logistic.client.slack.domain.entity.SlackEntity;
 import com.rush.logistic.client.slack.domain.global.ApiResponse;
 import com.rush.logistic.client.slack.domain.global.exception.slack.NotFoundSlackException;
 import com.rush.logistic.client.slack.domain.global.exception.slack.NotFoundSlackIdException;
 import com.rush.logistic.client.slack.domain.global.exception.slack.SlackSendErrorException;
 import com.rush.logistic.client.slack.domain.repository.SlackRepository;
+import com.rush.logistic.client.slack.domain.repository.SlackRepositoryImpl;
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.util.List;
 
 
 @Service
@@ -41,6 +42,7 @@ public class SlackService {
 
     private final SlackRepository slackRepository;
     private final UserClient userClient;
+    private final SlackRepositoryImpl slackRepositoryImpl;
 
     @Value(value = "${slack.token}")
     String slackToken;
@@ -114,20 +116,18 @@ public class SlackService {
         }
     }
 
-    public Page<SlackInfoResponseDto> getAllSlacks(String role, String authenticatedUserId, Pageable pageable, Integer size) {
+    public Page<SlackEntity> getAllSlacks(String role, String authenticatedUserId, Pageable pageable, Integer size) {
 
         ApiResponse<UserResponseDto> response = userClient.getUserById(authenticatedUserId, role, authenticatedUserId);
 
-        return slackRepository.findAll(pageable).map(SlackInfoResponseDto::from);
+        return slackRepositoryImpl.findAll(pageable,size);
     }
 
-    public SlackInfoResponseDto getSlack(String role, String authenticatedUserId, String slackId) {
+    public SlackEntity getSlack(String role, String authenticatedUserId, String slackId) {
 
         ApiResponse<UserResponseDto> response = userClient.getUserById(authenticatedUserId, role, authenticatedUserId);
 
-        SlackEntity slackentity = slackRepository.findById(Long.valueOf(slackId)).orElseThrow(NotFoundSlackException::new);
-
-        return SlackInfoResponseDto.from(slackentity);
+        return slackRepositoryImpl.findBySlackId(Long.valueOf(slackId));
     }
 
     @Transactional(readOnly = false)
@@ -155,4 +155,23 @@ public class SlackService {
 
         return SlackInfoResponseDto.from(slackentity);
     }
+
+    public List<SlackEntity> getSlackByMessage(String role, String authenticatedUserId, String message) {
+
+        ApiResponse<UserResponseDto> response = userClient.getUserById(authenticatedUserId, role, authenticatedUserId);
+
+        return slackRepositoryImpl.findByMessage(message);
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+

--- a/com.rush.logistic.client.user-auth/src/main/java/com/rush/logistic/client/domain/user/dto/UserUpdateRequestDto.java
+++ b/com.rush.logistic.client.user-auth/src/main/java/com/rush/logistic/client/domain/user/dto/UserUpdateRequestDto.java
@@ -1,7 +1,12 @@
 package com.rush.logistic.client.domain.user.dto;
 
 import com.rush.logistic.client.domain.user.enums.UserRoleEnum;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Getter
 @Builder
@@ -12,4 +17,7 @@ public class UserUpdateRequestDto {
     private String username;
     private UserRoleEnum role;
     private String email;
+    private UUID hubId;
+    private UUID companyId;
+    private UUID deliveryId;
 }

--- a/com.rush.logistic.client.user-auth/src/main/java/com/rush/logistic/client/domain/user/entity/User.java
+++ b/com.rush.logistic.client.user-auth/src/main/java/com/rush/logistic/client/domain/user/entity/User.java
@@ -6,8 +6,8 @@ import com.rush.logistic.client.domain.user.enums.UserRoleEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 
 @Entity
@@ -36,10 +36,24 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
+    //
+
+    @Column(name = "hub_id", unique = true)
+    private UUID hubId;
+
+    @Column(name = "company_id", unique = true)
+    private UUID companyId;
+
+    @Column(name = "delivery_id", unique = true)
+    private UUID deliveryId;
+
     public void updateUser(UserUpdateRequestDto requestDto){
 
         Optional.ofNullable(requestDto.getUsername()).ifPresent(username -> this.username = username);
         Optional.ofNullable(requestDto.getRole()).ifPresent(role -> this.role = role);
         Optional.ofNullable(requestDto.getEmail()).ifPresent(email -> this.email = email);
+        Optional.ofNullable(requestDto.getHubId()).ifPresent(huhId -> this.hubId = huhId);
+        Optional.ofNullable(requestDto.getCompanyId()).ifPresent(companyId -> this.companyId = companyId);
+        Optional.ofNullable(requestDto.getDeliveryId()).ifPresent(deliveryId -> this.deliveryId = deliveryId);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#### slack  - QueryDSL 추가
#### user - 담당자 UUID 추가

UUID 관련해서 추가하였습니다. 다른 서비스에서 활용이 잦을것 같아 간단하게 PR 작성하였습니다.

아래는 슬랙에 정리해놓은 정리본입니다!

## PR 타입

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

```java
@Column(name = "hub_id", unique = true)
private UUID hubId;

@Column(name = "company_id", unique = true)
private UUID companyId;

@Column(name = "delivery_id", unique = true)
private UUID deliveryId;
```
희승님과 논의해본 결과 각 담당자들이 자기 자신의 hub / company / delivery를 가지고 있어야 한다고 생각되어 user entity에 넣어놓았습니다!
추후에 담당 hub / company / delivery 설정할때 여기에 넣으시면 될거같아요

---

> 발제문서에 이런식으로 권한이 필요한데, 희승님과 논의해본 결과 다음과 같은 결론이 나왔습니다.
마지막 정리본만 보시면 이해하시기 쉬우실것 같습니다


다른 권한인 사람이 조회하려고 하면 예외 처리 해야함. 마스터만 하는건 따로 빼던가?
지금 메서드는 조회를 원하는 사람의 id와 내 아이디가 일치하면 조회 가능
권한은 체크하지 않고있음(마스터는 모두 가능)

발제에 문서 보면 좀더 고민..
담당 허브가 여러개, 여러명일때 좀 더 생각

정리하자면

> 각 애플리케이션의 서비스에서
로그인한 유저의 권한 체크 -> 게이트웨이를 통해서 가져온 헤더의 role과 UserRoleEnum 자체를 그냥 equals로 비교하면 끝
담당 허브(본인 업체) 체크 -> getUserById를 통해서 유저를 가져온다음에 담당허브가 맞는지 체크 하면 끝
유저 코드 변경점은 없습니다!

![image](https://github.com/user-attachments/assets/56b92a4f-b28e-4db2-99df-363b4b96a9d7)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

